### PR TITLE
Fix lifecycle build, which recently got this error:

### DIFF
--- a/build/files/lifecycle.dockerfile
+++ b/build/files/lifecycle.dockerfile
@@ -24,6 +24,7 @@ RUN apk --no-cache add -t .build \
     libffi-dev \
     openssl-dev \
     python3-dev \
+  && pip3 install --upgrade pip \
   && pip3 --no-cache-dir install ansible docker \
   && apk del .build
 COPY lifecycle /usr/local/bin/lifecycle


### PR DESCRIPTION
    Could not find a version that satisfies the requirement cffi>=1.4.1

It seems the old pip3 version shipped by Alpine is unable to resolve dependencies properly.