### PR TITLE
Add an absolutely shared path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,9 @@
     privileged: true
     purge_networks: true
     state: "{{ item.test_playground_state|d(test_playground_state) }}"
-    volumes: /sys/fs/cgroup:/sys/fs/cgroup:ro
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /tmp/{{ item.inventory_hostname }}:/tmp/{{ item.inventory_hostname }}
     tmpfs:
       - /run
       - /run/lock
@@ -46,10 +48,15 @@
     map('extract', hostvars)|list
   }}"
 
-- name: delete test playground networks
-  docker_network:
-    name: "{{ item.name }}"
-    state: absent
-  loop: *network_loop
-  when:
-    - test_playground_state == 'absent'
+- when: test_playground_state == 'absent'
+  block:
+    - name: delete shared absolute folder
+      file:
+        path: /tmp/{{ item.inventory_hostname }}
+        state: absent
+
+    - name: delete test playground networks
+      docker_network:
+        name: "{{ item.name }}"
+        state: absent
+      loop: *network_loop

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,20 @@ server1 test_playground_tag=ubuntu-18.04
 ansible_connection=docker
 ```
 
+### Shared absolute path
+
+When using privileged containers to mimic virtual machine behaviors, sometimes
+you will need to test things such as mounting loop devices.
+
+To be able to mount a loop device from within a container, the absolute path
+must be the same in the host and in the container.
+
+By sharing a predictable absolute path, there's a place where to store such
+things and make things work.
+
+Summarizing, `server0` will have a `/tmp/server0` folder bind mounted from
+its host's `/tmp/server0` folder. The same for `server1`, etc.
+
 ## The Playbooks
 
 We will use 3 playbooks to properly test your role.


### PR DESCRIPTION
When using privileged containers to mimic virtual machine behaviors, sometimes
you will need to test things such as mounting loop devices.


To be able to mount a loop device from within a container, the absolute path
must be the same in the host and in the container.

By sharing a predictable absolute path, there's a place where to store such
things and make things work.

Summarizing, `server0` will have a `/tmp/server0` folder bind mounted from
its host's `/tmp/server0` folder. The same for `server1`, etc.